### PR TITLE
Use 'awk' in place of 'bc' for wider platform support

### DIFF
--- a/only_scroll_sometimes.sh
+++ b/only_scroll_sometimes.sh
@@ -1,6 +1,6 @@
 SCROLL_RATIO=$1
 
-num_scrolls_to_scroll=`bc <<< "1/$SCROLL_RATIO"`
+num_scrolls_to_scroll=`awk "BEGIN { print int( 1/$SCROLL_RATIO ) }"`
 get_count_cmd=`tmux show-environment -g __scroll_copy_mode__slow_scroll_count`
 eval $get_count_cmd
 

--- a/scroll_copy_mode.tmux
+++ b/scroll_copy_mode.tmux
@@ -35,11 +35,11 @@ bind_wheel_up_to_enter_copy_mode() {
   fi
 
   send_keys_to_tmux_cmd=""
-  if [ $(echo " $scroll_speed_num_lines_per_scroll >= 1" | bc) -eq 1 ] ; then  # Positive whole number speed (round down).
+  if [ $(awk "BEGIN { print $scroll_speed_num_lines_per_scroll >= 1 }") -eq 1 ] ; then  # Positive whole number speed (round down).
     for i in `seq 1 "$scroll_speed_num_lines_per_scroll"` ; do
       send_keys_to_tmux_cmd=$send_keys_to_tmux_cmd"send-keys -M ; "
     done
-  elif [ $(echo " $scroll_speed_num_lines_per_scroll >= 0" | bc) -eq 1 ] ; then  # Positive decimal between 0 and 1 (treat as percent).
+  elif [ $(awk "BEGIN { print $scroll_speed_num_lines_per_scroll >= 0 }") -eq 1 ] ; then  # Positive decimal between 0 and 1 (treat as percent).
     # Skip enough scrolls so that we scroll only on the specified percent of scrolls.
     tmux set-environment __scroll_copy_mode__slow_scroll_count 0;
     send_keys_to_tmux_cmd="if -t = \\\"$CURRENT_DIR/only_scroll_sometimes.sh $scroll_speed_num_lines_per_scroll\\\" \\\"send-keys -M\\\" \\\"\\\"";


### PR DESCRIPTION
`bc` is not installed by default on many systems while `awk` is pre-installed on most systems and defined as _core_ or _base_ package in those systems.

So I think it would be better to use `awk` for wider platform support.
