### PR TITLE
Do not enable plugin for tmux version less 2.1

### DIFF
--- a/scroll_copy_mode.tmux
+++ b/scroll_copy_mode.tmux
@@ -78,4 +78,6 @@ bind_wheel_up_to_enter_copy_mode() {
       "
 }
 
-bind_wheel_up_to_enter_copy_mode
+if [ `tmux -V | tr '.' ',' | awk '{print ($2 >= 2.1)}'` -eq 1 ]; then
+  bind_wheel_up_to_enter_copy_mode
+fi


### PR DESCRIPTION
I share .tmux configuration across multiple machines. They have different versions of tmux and plugin doesn't work at some of them.
Unfortunately I cannot exclude plugin via if-shell statement due tpm limitations.
