### PR TITLE
Comparisons & arithmetic expansion POSIX compatibility

### DIFF
--- a/only_scroll_sometimes.sh
+++ b/only_scroll_sometimes.sh
@@ -9,7 +9,7 @@ eval $get_count_cmd
 CURRENT_COUNT=$__scroll_copy_mode__slow_scroll_count
 
 # Now increment and loop around if we've finished the scroll cycle.
-((__scroll_copy_mode__slow_scroll_count = (__scroll_copy_mode__slow_scroll_count + 1 ) % num_scrolls_to_scroll))
+__scroll_copy_mode__slow_scroll_count=$(( (__scroll_copy_mode__slow_scroll_count + 1) % num_scrolls_to_scroll))
 
 
 # Store the new value in tmux.

--- a/scroll_copy_mode.tmux
+++ b/scroll_copy_mode.tmux
@@ -37,17 +37,17 @@ bind_wheel_up_to_enter_copy_mode() {
   local enter_copy_mode_cmd="copy-mode"
   local select_moused_over_pane_cmd=""
   local check_for_fullscreen_alternate_buffer=""
-  if [ "$scroll_down_to_exit" == 'on' ] ; then
+  if [ "$scroll_down_to_exit" = 'on' ] ; then
       enter_copy_mode_cmd="copy-mode -e"
   fi
-  if [ "$scroll_in_moused_over_pane" == 'on' ] ; then
+  if [ "$scroll_in_moused_over_pane" = 'on' ] ; then
       select_moused_over_pane_cmd="select-pane -t= ;"
   fi
-  if [ "$scroll_without_changing_pane" == 'on' ] ; then
+  if [ "$scroll_without_changing_pane" = 'on' ] ; then
     enter_copy_mode_cmd="$enter_copy_mode_cmd -t="
     select_moused_over_pane_cmd=""
   fi
-  if [ "$emulate_scroll_for_no_mouse_alternate_buffer" == 'on' ] ; then
+  if [ "$emulate_scroll_for_no_mouse_alternate_buffer" = 'on' ] ; then
     check_for_fullscreen_alternate_buffer="#{alternate_on}"
   fi
 


### PR DESCRIPTION
`/usr/bin/env sh` on Debian-based (and possibly other) Linux systems is actually the `dash` shell, which is a strictly POSIX-compatible shell that does not support any "bashisms".

This PR fixes those bashisms so that they work on these systems. The other option was to change the script interpreter to bash explicitly, but dash is more performant than bash.

Fixes most of #19, except that Vim scrolling still doesn't work.
