### PR TITLE
Fix bash range in get_repeated_scroll_cmd function

### DIFF
--- a/scroll_copy_mode.tmux
+++ b/scroll_copy_mode.tmux
@@ -15,7 +15,7 @@ get_repeated_scroll_cmd() {
   local scroll_speed_num_lines_per_scroll=$(get_tmux_option "$scroll_speed_num_lines_per_scroll_option" "3")
   local cmd=""
   if echo - | awk "{ if ($scroll_speed_num_lines_per_scroll >= 1) { exit 0 } else { exit 1 } }" ; then  # Positive whole number speed (round down).
-    for i in {1.."$scroll_speed_num_lines_per_scroll"} ; do
+    for ((i = 1; i <= scroll_speed_num_lines_per_scroll; i++)); do
       cmd=$cmd"send-keys $1 ; "
     done
   elif echo - | awk "{ if ($scroll_speed_num_lines_per_scroll > 0) { exit 0 } else { exit 1 } }" ; then  # Positive decimal between 0 and 1 (treat as percent).


### PR DESCRIPTION
In #28, I changed the for loop in the `get_repeated_scroll_cmd` function to use a bash built-in because `seq` is not portable (for example, it doesn't exist on Solaris).  However, I must have been accidentally testing under ZSH, because the range operator (`{1..x}`) does not support variable interpolation under bash.  This commit changes the for loop to using a math operator, which I have confirmed is compatible with bash (at least back to version 3, which is quite old); and as a built-in, is portable.